### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Cod-e-Codes/marchat/security/code-scanning/1](https://github.com/Cod-e-Codes/marchat/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Since the workflow primarily reads repository contents and does not perform write operations, we can set `contents: read` as the permission. This ensures the `GITHUB_TOKEN` has only read access to the repository contents, reducing the risk of unintended write operations.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or within the `build` job to limit permissions specifically for that job. In this case, adding it at the root level is more concise and ensures consistency across all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
