### PR TITLE
update dockerfile for build args fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@
 FROM golang:1.24-alpine AS builder
 
 # Build arguments for version information
-ARG VERSION=dev
-ARG BUILD_TIME=unknown
-ARG GIT_COMMIT=unknown
+ARG GIT_COMMIT
+ARG BUILD_TIME
+ARG VERSION
 
 WORKDIR /marchat
 COPY . .


### PR DESCRIPTION
This update changes the argument variables in the Dockerfile to prep to pull version and commit info into docker build.